### PR TITLE
Make count and capacity mutable to avoid compilation issues on rpi?

### DIFF
--- a/src/SimpleVector.h
+++ b/src/SimpleVector.h
@@ -10,8 +10,8 @@ template<typename T>
 class SimpleVector {
 private:
     T* array;
-    unsigned int count;
-    unsigned int capacity;
+    mutable unsigned int count;
+    mutable unsigned int capacity;
 
     /**
      * @brief Resize the array to the specified capacity


### PR DESCRIPTION
Ran into this issue when compiling my libraries on RP2040/RP2350 with earlephilhower core:-

`error: assignment of member 'SimpleVector<T>::count' in read-only object`

(Seems to compile fine on my Teensy project, though).

This simple patch resolves the error and everything seems to work fine.  Would be good to have it patched upstream too.

Thanks :)

